### PR TITLE
fix: add AddTags permission for new launch cluster requirement

### DIFF
--- a/aws_emr_launch/constructs/step_functions/emr_tasks.py
+++ b/aws_emr_launch/constructs/step_functions/emr_tasks.py
@@ -230,6 +230,7 @@ class EmrCreateClusterTask(BaseTask):
         policy_statements.append(
             iam.PolicyStatement(
                 actions=[
+                    "elasticmapreduce:AddTags",
                     "elasticmapreduce:RunJobFlow",
                     "elasticmapreduce:DescribeCluster",
                     "elasticmapreduce:TerminateJobFlows",


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- launching clusters now requires the AddTags permission on "*" resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
